### PR TITLE
feat: Add timer type selection and Docker cleanup options

### DIFF
--- a/scripts/install-solarstorm.sh
+++ b/scripts/install-solarstorm.sh
@@ -338,11 +338,11 @@ Requires=solarstorm-scout.service
 
 [Timer]
 # Fixed schedule - runs at exact times
+# Note: Will NOT run on boot - only at scheduled times or manual trigger
 $CALENDAR_ENTRIES
 
 # Allow some timing jitter to reduce load spikes
 AccuracySec=1min
-Persistent=true
 
 [Install]
 WantedBy=timers.target

--- a/systemd/solarstorm-scout.timer.template
+++ b/systemd/solarstorm-scout.timer.template
@@ -5,7 +5,7 @@ Requires=solarstorm-scout.service
 
 [Timer]
 # Run on timer - default 1.5 hours (90 minutes)
-OnBootSec=5min
+# Note: Will NOT run on boot - only on schedule or manual trigger
 OnUnitActiveSec=%INTERVAL_SECONDS%s
 
 # Allow some timing jitter to reduce load spikes


### PR DESCRIPTION
Install script enhancements:
- Add timer type selection (relative vs fixed schedule)
- Option 1: Relative timing (OnUnitActiveSec) - posts X hours after previous run
- Option 2: Fixed schedule (OnCalendar) - posts at exact times (00:00, 01:30, 03:00...)
- Automatically generates OnCalendar entries based on interval
- Default to fixed schedule (option 2)

Uninstall script enhancements:
- Detect and offer to remove Docker images
- Remove both local (solarstorm-scout:local) and GHCR images
- Interactive prompt for Docker cleanup
- Preserve configuration and logs by default