### PR TITLE
chore: consolidate dependency updates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -118,7 +118,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Bandit report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: bandit-report-${{ github.sha }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,7 +33,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -84,7 +84,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,7 +30,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Review dependency changes
       uses: actions/dependency-review-action@v4

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -28,7 +28,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -50,7 +50,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Safety report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: safety-vulnerability-report
@@ -58,7 +58,7 @@ jobs:
         retention-days: 30
 
     - name: Upload pip-audit report
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: pip-audit-report

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     
     - name: Set lowercase image name
       id: image-name

--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -33,7 +33,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Set up Snyk CLI
       uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Python 3.11+ (numpy 2.3+ requires Python 3.11)
 
 # Core dependencies
-aiohttp==3.13.2
+aiohttp==3.13.3
 atproto==0.0.63
 Mastodon.py==2.1.4
 python-dotenv==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Core dependencies
 aiohttp==3.13.2
-atproto==0.0.63
+atproto==0.0.65
 Mastodon.py==2.1.4
 python-dotenv==1.2.1
 matplotlib==3.10.7


### PR DESCRIPTION
Consolidates dependabot dependency updates into a single PR:

- Bump actions/checkout from 5 to 6
- Bump actions/upload-artifact from 5 to 6
- Bump aiohttp from 3.13.2 to 3.13.3
- Bump atproto from 0.0.63 to 0.0.65