### PR TITLE
Add macvlan network override example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ htmlcov/
 
 # Docker
 *.dockerfile.swp
+docker-compose.override.yml
 
 # Anti-spam tracking
 .last_run

--- a/docker-compose.macvlan.example.yml
+++ b/docker-compose.macvlan.example.yml
@@ -1,0 +1,54 @@
+# Macvlan Network Override Example
+# ============================================================
+# Use this to place the containers on a macvlan network with
+# static IPs on your LAN. Useful for VLAN segmentation or when
+# you need the bot to appear as its own host on the network.
+#
+# NOTE: If you use the systemd installer (scripts/install-solarstorm.sh)
+# with Docker mode, the container runs via `docker run` in a systemd
+# unit and you'll need to add --network and --dns flags to the
+# generated service file at /etc/systemd/system/solarstorm-scout.service.
+#
+# Setup:
+#   1. Create the macvlan network (adjust parent/subnet for your LAN):
+#      docker network create -d macvlan \
+#        --subnet=192.168.1.0/24 \
+#        --gateway=192.168.1.1 \
+#        -o parent=eth0 \
+#        my-macvlan
+#
+#   2. Copy this file:
+#      cp docker-compose.macvlan.example.yml docker-compose.override.yml
+#
+#   3. Edit the IP addresses, DNS, and network name to match your setup.
+#
+#   4. Start normally — the override is picked up automatically:
+#      docker compose up -d
+#
+# For systemd mode, add these flags to ExecStart in the service file:
+#   --network=my-macvlan --dns=192.168.1.1
+#
+# Note: docker-compose.override.yml is gitignored so your local
+# config won't conflict with upstream updates.
+# ============================================================
+
+services:
+  solarstorm-scout:
+    networks:
+      my-macvlan:
+        ipv4_address: 192.168.1.55
+    dns:
+      - 192.168.1.1
+
+  # Ofelia scheduler — only needs macvlan if it must reach
+  # external services directly (usually not needed)
+  # ofelia:
+  #   networks:
+  #     my-macvlan:
+  #       ipv4_address: 192.168.1.56
+  #   dns:
+  #     - 192.168.1.1
+
+networks:
+  my-macvlan:
+    external: true


### PR DESCRIPTION
Adds `docker-compose.macvlan.example.yml` for deploying the bot on a Docker macvlan network with a static LAN IP.

## What
- New file: `docker-compose.macvlan.example.yml`
- Updated `.gitignore` to exclude `docker-compose.override.yml`

## Usage
1. Create a macvlan Docker network on your host
2. Copy `docker-compose.macvlan.example.yml` to `docker-compose.override.yml`
3. Edit the IP address, DNS, and network name for your environment
4. Run `docker compose up -d` — the override is picked up automatically

## Systemd Timer Note
If using the systemd timer installer (`scripts/install-solarstorm.sh`), the `--network` and `--dns` flags need to be added to the generated service file at `/etc/systemd/system/solarstorm-scout.service` — the compose override only applies to `docker compose up`.

Ofelia scheduler generally doesn't need macvlan (commented example included if needed).

## Why
Useful for VLAN-segmented setups where the container needs its own IP on the LAN. This is optional — the default bridge networking continues to work as before.